### PR TITLE
configured object mapper to not fail if unexpected properties are found

### DIFF
--- a/utilities-core/src/main/java/uk/gov/justice/services/common/converter/jackson/ObjectMapperProducer.java
+++ b/utilities-core/src/main/java/uk/gov/justice/services/common/converter/jackson/ObjectMapperProducer.java
@@ -2,6 +2,7 @@ package uk.gov.justice.services.common.converter.jackson;
 
 import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_ABSENT;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static com.fasterxml.jackson.databind.DeserializationFeature.READ_ENUMS_USING_TO_STRING;
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_WITH_ZONE_ID;
@@ -55,6 +56,7 @@ public class ObjectMapperProducer {
                 .setTimeZone(getTimeZone(UTC))
                 .setSerializationInclusion(NON_ABSENT)
                 .enable(WRITE_ENUMS_USING_TO_STRING)
+                .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .enable(READ_ENUMS_USING_TO_STRING);
     }
 

--- a/utilities-core/src/test/java/uk/gov/justice/services/common/converter/ObjectMapperProducerTest.java
+++ b/utilities-core/src/test/java/uk/gov/justice/services/common/converter/ObjectMapperProducerTest.java
@@ -10,6 +10,8 @@ import static org.junit.Assert.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 import static uk.gov.justice.services.common.converter.ObjectMapperProducerTest.Colour.BLUE;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.justice.services.common.converter.jackson.ObjectMapperProducer;
 
 import java.util.Collections;
@@ -75,6 +77,14 @@ public class ObjectMapperProducerTest {
         final String json = mapper.writeValueAsString(source);
 
         assertEquals(JSON_OBJECT_STRING, json, true);
+    }
+
+    @Test
+    public void shouldTolerateAdditionalPropertiesFromJsonObjects() throws Exception {
+
+        final String json = "{\"name\":\"Fred\",\"age\":42,\"favouriteColour\":\"Blue\", \"something\": \"else\"}";
+
+        mapper.readValue(json, Person.class);
     }
 
     @Test
@@ -299,7 +309,6 @@ public class ObjectMapperProducerTest {
         private String name;
         private int age;
         private Map<String, Object> additionalProperties;
-
 
         public PersonWithAdditionalProperties(final String name, final int age, final Map<String, Object> additionalProperties) {
             this.name = name;


### PR DESCRIPTION
Well... 

Its practice now to set 'allowaddtionalProperties=true' in all our schemas.  Unfortunately, the currently configured ObjectMapperProducer's configuration is not in accord with this policy.