### PR TITLE
[AA] addint today() to return localDate in UTC TZ

### DIFF
--- a/utilities-core/src/main/java/uk/gov/justice/services/common/util/Clock.java
+++ b/utilities-core/src/main/java/uk/gov/justice/services/common/util/Clock.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.services.common.util;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 
 /**
@@ -8,4 +9,6 @@ import java.time.ZonedDateTime;
 public interface Clock {
 
     ZonedDateTime now();
+
+    LocalDate today();
 }

--- a/utilities-core/src/main/java/uk/gov/justice/services/common/util/UtcClock.java
+++ b/utilities-core/src/main/java/uk/gov/justice/services/common/util/UtcClock.java
@@ -2,6 +2,7 @@ package uk.gov.justice.services.common.util;
 
 import static java.time.ZoneOffset.UTC;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -15,5 +16,10 @@ public class UtcClock implements Clock {
     @Override
     public ZonedDateTime now() {
         return ZonedDateTime.now(UTC);
+    }
+
+    @Override
+    public LocalDate today() {
+        return LocalDate.now(UTC);
     }
 }

--- a/utilities-core/src/test/java/uk/gov/justice/services/common/util/UtcClockTest.java
+++ b/utilities-core/src/test/java/uk/gov/justice/services/common/util/UtcClockTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 
 import org.junit.Test;
@@ -31,5 +32,11 @@ public class UtcClockTest {
 
         assertThat(zonedDateTime.isAfter(now().minusSeconds(2L)), is(true));
         assertThat(zonedDateTime.getZone(), is(UTC));
+    }
+
+    @Test
+    public void shouldGetTodaysDate() throws Exception {
+        final LocalDate today = clock.today();
+        assertThat(today, is(LocalDate.now(UTC)));
     }
 }


### PR DESCRIPTION
Currently, we are dong `utcClock.now().toLocalDate()` to get the LocalDate in UTC TZ.
Adding `today()` which return the localdate